### PR TITLE
Add PayloadStatus class

### DIFF
--- a/src/PayloadStatus.php
+++ b/src/PayloadStatus.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ */
+namespace Aura\Payload_Interface;
+
+/**
+ *
+ * Describe Payload Statuses.
+ *
+ * @package Aura.Payload_Interface
+ *
+ */
+class PayloadStatus
+{
+    const ACCEPTED = 'ACCEPTED';
+    const AUTHENTICATED = 'AUTHENTICATED';
+    const AUTHORIZED = 'AUTHORIZED';
+    const CREATED = 'CREATED';
+    const DELETED = 'DELETED';
+    const ERROR = 'ERROR';
+    const FAILURE = 'FAILURE';
+    const FOUND = 'FOUND';
+    const NOT_ACCEPTED = 'NOT_ACCEPTED';
+    const NOT_AUTHENTICATED = 'NOT_AUTHENTICATED';
+    const NOT_AUTHORIZED = 'NOT_AUTHORIZED';
+    const NOT_CREATED = 'NOT_CREATED';
+    const NOT_DELETED = 'NOT_DELETED';
+    const NOT_FOUND = 'NOT_FOUND';
+    const NOT_UPDATED = 'NOT_UPDATED';
+    const NOT_VALID = 'NOT_VALID';
+    const PROCESSING = 'PROCESSING';
+    const SUCCESS = 'SUCCESS';
+    const UPDATED = 'UPDATED';
+    const VALID = 'VALID';
+}


### PR DESCRIPTION
**Allows use of standard status without requiring implementation.**

As per my comment in PR #2 (On Statuses)

This adds a "PayloadStatus" class, similar to  [Psr\Log\LogLevel](https://github.com/php-fig/log/blob/master/Psr/Log/LogLevel.php)

This allows one to require the interface and use standard status codes, without requiring the implementation

``` php

use Aura\Payload_Interface\PayloadStatus;
use Aura\Payload_Interface\PayloadInterface;

class Domain
{
    protected $payload;

    public function __construct(PayloadInterface $payload)
    {
        $this->payload = $payload;
    }

    public function __invoke($input)
    {
        return $this->payload->setStatus(PayloadStatus::SUCCESS);
    }
}

```

Thoughts?
